### PR TITLE
fix(ci): update create-release.yml version regex for new format

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -39,7 +39,7 @@ jobs:
             exit 1
           fi
           VERSION=$(jq -r '.version' version.json)
-          if ! echo "$VERSION" | grep -Eq '^[0-9]{4}\.[1-9][0-9]{2,3}\.[0-9]{1,2}[0-9]{4}$'; then
+          if ! echo "$VERSION" | grep -Eq '^[0-9]{4}\.[1-9][0-9]?\.[1-9][0-9]?\.[0-2][0-9][0-5][0-9]$'; then
             echo "Invalid version format: $VERSION" >&2
             exit 1
           fi


### PR DESCRIPTION
- Updated version validation regex to match YYYY.M.D.HHmm format
- Changed from '^[0-9]{4}\.[1-9][0-9]{2,3}\.[0-9]{1,2}[0-9]{4}$' to '^[0-9]{4}\.[1-9][0-9]?\.[1-9][0-9]?\.[0-2][0-9][0-5][0-9]$'
- Fixes workflow failure when validating version 2025.9.22.1406
- Aligns with unified 4-segment time-based version scheme